### PR TITLE
haproxy代理设置超时时间为10分钟，避免进入容器过早退出

### DIFF
--- a/roles/lb/templates/haproxy.cfg.j2
+++ b/roles/lb/templates/haproxy.cfg.j2
@@ -12,8 +12,8 @@ global
 defaults
         log     global
         timeout connect 5000
-        timeout client  50000
-        timeout server  50000
+        timeout client  10m
+        timeout server  10m
 
 listen kube-master
         bind 0.0.0.0:{{ MASTER_PORT }}


### PR DESCRIPTION
使用haproxy代理apiserver后，每次通过vip进入集群，1分钟不操作就会自动退出，而在master节点上进入容器则不会有这种情况，经过排查发现这是由于haproxy的超时时间设置为50s，时间过短，不利于进入容器的操作交互，将haproxy超时时间设置为10m，体验会更好一些，我们是用于生产环境的。
具体参见：[https://github.com/kubernetes/kubernetes/issues/59411](url)