### PR TITLE
新增不同版本linux初始化ansible及kubernetes相关组件的脚本

### DIFF
--- a/tools/basic-env-setup.sh
+++ b/tools/basic-env-setup.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+set -e
+
+# curl http://filecdn.code2life.top/ansible_k8s_setup.sh | sh -s
+
+# 默认1.10.0 版本的 Kubernetes
+bin_resource_url='http://filecdn.code2life.top/k8s.1100.tar.gz'
+
+# 如果参数指定k8s相关的bin以指定的为准, 例如: k8s.193.tar.gz
+if [ "$1" ];then
+  bin_resource_url="http://filecdn.code2life.top/"$1
+fi
+
+# 各Linux版本安装python/pip
+# ---------------------------
+
+# debian 默认的apt源在国内访问很慢, 可手动修改/etc/apt/source.list修改为其他源
+# 以 debian 9 为例, source.list可修改为如下内容, ubuntu修改方法类似, 找到相应系统和版本的镜像源替换即可
+# deb http://mirrors.163.com/debian/  stretch main non-free contrib
+# deb http://mirrors.163.com/debian/  stretch-updates main non-free contrib
+# deb http://mirrors.163.com/debian/  stretch-backports main non-free contrib
+# deb http://mirrors.163.com/debian-security/  stretch/updates main non-free contrib
+basic_ubuntu_debian() {
+  echo "Setup Basic Environment for Ubuntu/Debian."
+  apt-get update && apt-get upgrade -y && apt-get dist-upgrade -y
+  apt-get install python2.7 git python-pip curl -y
+
+  if [ ! -f /usr/bin/python ];then
+    ln -s /usr/bin/python2.7 /usr/bin/python
+  fi
+}
+
+# 红帽系Liunx可修改yum源加快下载速度, 修改/etc/yum.repos.d内文件即可
+basic_centos() {
+  echo "Setup Basic Environment for CentOS."
+  yum install epel-release -y
+  yum update -y
+  yum erase firewalld firewalld-filesystem python-firewall -y
+  yum install git python python-pip curl -y
+}
+
+basic_fedora() {
+  echo "Setup Basic Environment for Fedora."
+  yum update -y
+  yum install git python python-pip curl -y
+}
+
+# archlinux 使用pacman进行包管理
+basic_arch() {
+  pacman -Syu --noconfirm
+  pacman -S python git python-pip curl --noconfirm
+}
+
+# 使用pip安装ansible, 并下载k8s相关bin文件
+setup_ansible_k8s() {
+  echo "Download Ansible and Kubernetes binaries."
+  pip install pip --upgrade -i http://mirrors.aliyun.com/pypi/simple/ --trusted-host mirrors.aliyun.com
+  pip install --no-cache-dir ansible -i http://mirrors.aliyun.com/pypi/simple/ --trusted-host mirrors.aliyun.com
+
+  git clone https://github.com/gjmzj/kubeasz.git
+  mv kubeasz /etc/ansible
+
+  # Download from CDN & Move bin files
+  curl -o k8s_download.tar.gz "$bin_resource_url"
+  tar zxvf k8s_download.tar.gz
+  mv -f bin/* /etc/ansible/bin
+  rm -rf bin
+  echo "Finish setup. Please config your hosts and run 'ansible-playbook' command at /etc/ansible."
+}
+# ---------------------------
+
+# 判断Linux发行版, 执行不同基础环境设置方法
+# ---------------------------
+lsb_dist=''
+command_exists() {
+    command -v "$@" > /dev/null 2>&1
+}
+if command_exists lsb_release; then
+    lsb_dist="$(lsb_release -si)"
+    lsb_version="$(lsb_release -rs)"
+fi
+if [ -z "$lsb_dist" ] && [ -r /etc/lsb-release ]; then
+    lsb_dist="$(. /etc/lsb-release && echo "$DISTRIB_ID")"
+    lsb_version="$(. /etc/lsb-release && echo "$DISTRIB_RELEASE")"
+fi
+if [ -z "$lsb_dist" ] && [ -r /etc/debian_version ]; then
+    lsb_dist='debian'
+fi
+if [ -z "$lsb_dist" ] && [ -r /etc/fedora-release ]; then
+    lsb_dist='fedora'
+fi
+if [ -z "$lsb_dist" ] && [ -r /etc/os-release ]; then
+    lsb_dist="$(. /etc/os-release && echo "$ID")"
+fi
+if [ -z "$lsb_dist" ] && [ -r /etc/centos-release ]; then
+    lsb_dist="$(cat /etc/*-release | head -n1 | cut -d " " -f1)"
+fi
+if [ -z "$lsb_dist" ] && [ -r /etc/redhat-release ]; then
+    lsb_dist="$(cat /etc/*-release | head -n1 | cut -d " " -f1)"
+fi
+lsb_dist="$(echo $lsb_dist | cut -d " " -f1)"
+lsb_dist="$(echo "$lsb_dist" | tr '[:upper:]' '[:lower:]')"
+# ---------------------------
+
+# ---------------------------
+setup_env(){
+    case "$lsb_dist" in
+        centos)
+        basic_centos
+        setup_ansible_k8s
+        exit 0
+    ;;
+        fedora)
+        basic_fedora
+        setup_ansible_k8s
+        exit 0
+    ;;
+        ubuntu)
+        basic_ubuntu_debian
+        setup_ansible_k8s
+        exit 0
+    ;;
+        debian)
+        basic_ubuntu_debian
+        setup_ansible_k8s
+        exit 0
+    ;;
+        arch)
+        basic_arch
+        setup_ansible_k8s
+        exit 0
+    ;;
+        suse)
+        echo 'Not implementation yet.'
+        exit 1
+    esac
+    echo "Error: Unsupported OS, please set ansible environment manually."
+    exit 1
+}
+setup_env
+# ---------------------------

--- a/tools/basic-env-setup.sh
+++ b/tools/basic-env-setup.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-# curl http://filecdn.code2life.top/ansible_k8s_setup.sh | sh -s
+# curl http://filecdn.code2life.top/basic-env-setup.sh | sh -s
 
 # 默认1.10.0 版本的 Kubernetes
 bin_resource_url='http://filecdn.code2life.top/k8s.1100.tar.gz'

--- a/tools/basic-env-setup.sh
+++ b/tools/basic-env-setup.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-# curl http://filecdn.code2life.top/basic-env-setup.sh | sh -s
+# curl http://filecdn.code2life.top/kubeasz-basic-env-setup.sh | sh -s
 
 # 默认1.10.0 版本的 Kubernetes
 bin_resource_url='http://filecdn.code2life.top/k8s.1100.tar.gz'


### PR DESCRIPTION
Hi, 我在学习使用过程中发现有几个地方可以再自动化一些:
1. 对于一台裸机需要安装ansible, 但不同linux发行版包管理方式不同, 安装过程未自动化
2. 云盘中提供的打包好的kubernetes相关二进制文件非常方便, 但百度云会限速, 而且下载过程不方便使用curl/wget命令实现自动化.

我fork的版本中添加了一个shell脚本, 能够自动化的实现以下功能:
1. 支持在Ubuntu/CentOS/Fedora/ArchLinux中自动化的安装python+ansible;
2. clone kubeasz项目代码, 并将需要的二进制文件下载解压到/etc/ansible/bin中;
3. 支持带参数的运行, 如: ./basic-env-setup.sh k8s.193.tar.gz 指定不同的kubernetes二进制文件, 无参数时默认最新的k8s.1100.tar.gz (k8s 1.10.0 + etcd 3.3.2).

另外, 相关的二进制文件, 我同步到了个人在**七牛上的CDN存储中, 方便大家下载**: [filecdn.code2life.top](http://filecdn.code2life.top/); 
此PR的shell脚本也放在CDN中, 这样对于任何一台支持的linux设备, 执行一行
`curl http://filecdn.code2life.top/kubeasz-basic-env-setup.sh | sh -s` 
即可达到自动化安装ansible; 下载kubeasz项目; 下载各种二进制文件kubernetes+docker+etcd+... 这样的效果.

已经亲测centos7/ubuntu16.04/debian9/fedora27都是可以的, 二进制包下载速度贼快. 
脚本运行完毕之后, 只需到/etc/ansible目录下配置好hosts, 复制完ssh的公钥即可通过ansible-playbook迅速搭建集群了.





