### PR TITLE
永久关闭 selinux 失败，导致重启集群节点后8443等端口无法访问

### DIFF
--- a/roles/prepare/tasks/main.yml
+++ b/roles/prepare/tasks/main.yml
@@ -81,7 +81,7 @@
     - name: 永久关闭 selinux
       lineinfile:
         dest: /etc/selinux/config
-        regexp: "^SELINUX"
+        regexp: "^SELINUX="
         line: "SELINUX=disabled"
   when: ansible_distribution == "CentOS"
 


### PR DESCRIPTION
参考了这个文档并验证: [ansible 下lineinfile详细使用](https://www.cnblogs.com/jackchen001/p/6710233.html)