### PR TITLE
添加helm tls环境变量

### DIFF
--- a/roles/helm/tasks/main.yml
+++ b/roles/helm/tasks/main.yml
@@ -54,10 +54,10 @@
     regexp: 'helm completion'
     line: 'source <(helm completion bash)'
 
-# (DEPRECATED) 为方便与tiller进行安全通信，使用helms别名；helm v2.11.0 无法使用这个别名方式
-#- name: 配置helm命令别名
-#  lineinfile:
-#    dest: ~/.bashrc
-#    state: present
-#    regexp: "alias helms"
-#    line: "alias helms='helm --tls --tiller-namespace {{ helm_namespace }}'"
+# 为方便与tiller进行安全通信，启用helm tls环境变量；仅支持helm v2.11.0及以上版本
+- name: 配置helm tls环境变量
+  lineinfile:
+    dest: ~/.bashrc
+    state: present
+    regexp: "helm tls environment"
+    line: "export HELM_TLS_ENABLE=true"


### PR DESCRIPTION
通过引入该环境变量，执行helm命令与tiller通讯时，无需再手动添加`--tls`参数