### PR TITLE
移除 kube-node csr 请求批准部分

### DIFF
--- a/roles/kube-node/tasks/main.yml
+++ b/roles/kube-node/tasks/main.yml
@@ -95,18 +95,18 @@
   retries: 8
   delay: 2
 
-- name: 获取csr 请求信息
-  shell: "sleep 3 && {{ bin_dir }}/kubectl get csr"
-  delegate_to: "{{ groups.deploy[0] }}"
-  register: csr_info
-  run_once: true
+#- name: 获取csr 请求信息
+#  shell: "sleep 3 && {{ bin_dir }}/kubectl get csr"
+#  delegate_to: "{{ groups.deploy[0] }}"
+#  register: csr_info
+#  run_once: true
 
-- name: approve-kubelet-csr
-  shell: "{{ bin_dir }}/kubectl get csr|grep 'Pending' | awk 'NR>0{print $1}'| \
-        xargs {{ bin_dir }}/kubectl certificate approve"
-  when: '"Pending" in csr_info.stdout'
-  delegate_to: "{{ groups.deploy[0] }}"
-  run_once: true
+#- name: approve-kubelet-csr
+#  shell: "{{ bin_dir }}/kubectl get csr|grep 'Pending' | awk 'NR>0{print $1}'| \
+#        xargs {{ bin_dir }}/kubectl certificate approve"
+#  when: '"Pending" in csr_info.stdout'
+#  delegate_to: "{{ groups.deploy[0] }}"
+#  run_once: true
 
 - name: 轮询等待node达到Ready状态
   shell: "{{ bin_dir }}/kubectl get node {{ inventory_hostname }}|awk 'NR>1{print $2}'"


### PR DESCRIPTION
项目使用 cfssl 直接给 kubelet 签名，不需要 kube-apiserver 的批准。fixed issue 335