### PR TITLE
fix: 等待ETCD同步完成，再返回成功

### DIFF
--- a/roles/etcd/tasks/main.yml
+++ b/roles/etcd/tasks/main.yml
@@ -39,4 +39,13 @@
 
 - name: 开启etcd服务
   shell: systemctl daemon-reload && systemctl restart etcd
+  ignore_errors: true
+  tags: upgrade_etcd
+
+- name: 以轮询的方式等待服务同步完成
+  shell: "systemctl status etcd.service|grep Active"
+  register: etcd_status
+  until: '"running" in etcd_status.stdout'
+  retries: 8
+  delay: 8
   tags: upgrade_etcd


### PR DESCRIPTION
fix: 安装etcd，重启完成后，等待查看etcd状态，直到etcd集群选举完成。