### PR TITLE
添加支持RedHat

### DIFF
--- a/99.clean.yml
+++ b/99.clean.yml
@@ -179,11 +179,11 @@
     tags: rm_ntp 
     when: ansible_distribution == "Ubuntu" or ansible_distribution == "Debian"
 
-  - name: stop and disable chronyd in CentOS
+  - name: stop and disable chronyd in CentOS/RedHat
     service: name=chronyd state=stopped enabled=no
     ignore_errors: true
     tags: rm_ntp 
-    when: ansible_distribution == "CentOS" 
+    when: ansible_distribution == "CentOS" or ansible_distribution == "RedHat"
 
   - name: clean certs and keys
     file: name={{ item }} state=absent

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 |组件|支持|
 |:-|:-|
-|OS|Ubuntu 16.04+, CentOS 7|
+|OS|Ubuntu 16.04+, CentOS/RedHat 7|
 |k8s|v1.8, v1.9, v1.10, v1.11, v1.12|
 |etcd|v3.1, v3.2, v3.3|
 |docker|17.03.2-ce, 18.06.1-ce|

--- a/down/offline_images
+++ b/down/offline_images
@@ -20,6 +20,7 @@ cloudnativelabs/kube-router:v0.2.0
 mirrorgooglecontainers/kubernetes-dashboard-amd64:v1.10.0
 # pause 
 mirrorgooglecontainers/pause-amd64:3.1
+registry.access.redhat.com/rhel7/pod-infrastructure:latest
 busybox:1.28.4
 # traefik ingress 
 traefik:v1.7.4

--- a/roles/calico/defaults/main.yml
+++ b/roles/calico/defaults/main.yml
@@ -25,3 +25,13 @@ calico_kube_controller_ver: "v3.2.4"
 
 # 离线镜像tar包
 calico_offline: "calico_{{ calico_node_ver }}.tar"
+
+# 识别操作系统，加载对应的Pause容器离线镜像tar包
+OS_VER: "{{ ansible_distribution }}"
+for_redhat_pod: "rhel7-pod-infrastructure.tar"
+for_other_pod: "pause_3.1.tar"
+pause_offline: "{%- if OS_VER == 'RedHat' -%} \
+                {{ for_redhat_pod }} \
+              {%- else -%} \
+                {{ for_other_pod }} \
+              {%- endif -%}"

--- a/roles/calico/tasks/main.yml
+++ b/roles/calico/tasks/main.yml
@@ -53,7 +53,7 @@
   copy: src={{ base_dir }}/down/{{ item }} dest=/opt/kube/images/{{ item }}
   when: 'item in download_info.stdout'
   with_items:
-  - "pause_3.1.tar"
+  - "{{ pause_offline }}"
   - "{{ calico_offline }}"
   ignore_errors: true
 
@@ -66,7 +66,7 @@
   shell: "{{ bin_dir }}/docker load -i /opt/kube/images/{{ item }}"
   when: 'item in image_info.stdout'
   with_items:
-  - "pause_3.1.tar"
+  - "{{ pause_offline }}"
   - "{{ calico_offline }}"
   ignore_errors: true
 

--- a/roles/chrony/tasks/main.yml
+++ b/roles/chrony/tasks/main.yml
@@ -11,7 +11,7 @@
 - block:
   - name: 配置 chrony server 
     template: src=server-centos.conf.j2 dest=/etc/chrony.conf
-    when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "7"
+    when: (ansible_distribution == "CentOS" or ansible_distribution == "RedHat") and ansible_distribution_major_version == "7"
 
   - name: 配置 chrony server
     template: src=server-ubuntu.conf.j2 dest=/etc/chrony/chrony.conf
@@ -19,7 +19,7 @@
 
   - name: 启动 chrony server
     service: name=chronyd state=restarted enabled=yes
-    when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "7"
+    when: (ansible_distribution == "CentOS" or ansible_distribution == "RedHat") and ansible_distribution_major_version == "7"
   
   - name: 启动 chrony server
     service: name=chrony state=restarted enabled=yes
@@ -29,7 +29,7 @@
 - block:
   - name: 配置 chrony client
     template: src=client-centos.conf.j2 dest=/etc/chrony.conf
-    when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "7"
+    when: (ansible_distribution == "CentOS" or ansible_distribution == "RedHat") and ansible_distribution_major_version == "7"
 
   - name: 配置 chrony client
     template: src=client-ubuntu.conf.j2 dest=/etc/chrony/chrony.conf
@@ -37,7 +37,7 @@
 
   - name: 启动 chrony client 
     service: name=chronyd state=restarted enabled=yes
-    when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "7"
+    when: (ansible_distribution == "CentOS" or ansible_distribution == "RedHat") and ansible_distribution_major_version == "7"
 
   - name: 启动 chrony client
     service: name=chrony state=restarted enabled=yes

--- a/roles/cilium/defaults/main.yml
+++ b/roles/cilium/defaults/main.yml
@@ -20,3 +20,13 @@ cilium_ver: "v1.1.4"
 # 离线镜像tar包
 cilium_offline: "cilium_{{ cilium_ver }}.tar"
 busybox_offline: "busybox_{{ busybox_ver }}.tar"
+
+# 识别操作系统，加载对应的Pause容器离线镜像tar包
+OS_VER: "{{ ansible_distribution }}"
+for_redhat_pod: "rhel7-pod-infrastructure.tar"
+for_other_pod: "pause_3.1.tar"
+pause_offline: "{%- if OS_VER == 'RedHat' -%} \
+                {{ for_redhat_pod }} \
+              {%- else -%} \
+                {{ for_other_pod }} \
+              {%- endif -%}"

--- a/roles/cilium/tasks/main.yml
+++ b/roles/cilium/tasks/main.yml
@@ -59,7 +59,7 @@
   copy: src={{ base_dir }}/down/{{ item }} dest=/opt/kube/images/{{ item }}
   when: 'item in download_info.stdout'
   with_items:
-  - "pause_3.1.tar"
+  - "{{ pause_offline }}"
   - "{{ cilium_offline }}"
   - "{{ busybox_offline }}"
   ignore_errors: true
@@ -73,7 +73,7 @@
   shell: "{{ bin_dir }}/docker load -i /opt/kube/images/{{ item }}"
   when: 'item in image_info.stdout'
   with_items:
-  - "pause_3.1.tar"
+  - "{{ pause_offline }}"
   - "{{ cilium_offline }}"
   - "{{ busybox_offline }}"
   ignore_errors: true

--- a/roles/flannel/defaults/main.yml
+++ b/roles/flannel/defaults/main.yml
@@ -16,3 +16,13 @@ flanneld_image: "jmgao1983/flannel:v0.10.0-amd64"
 
 # 离线镜像tar包
 flannel_offline: "flannel_v0.10.0-amd64.tar"
+
+# 识别操作系统，加载对应的Pause容器离线镜像tar包
+OS_VER: "{{ ansible_distribution }}"
+for_redhat_pod: "rhel7-pod-infrastructure.tar"
+for_other_pod: "pause_3.1.tar"
+pause_offline: "{%- if OS_VER == 'RedHat' -%} \
+                {{ for_redhat_pod }} \
+              {%- else -%} \
+                {{ for_other_pod }} \
+              {%- endif -%}"

--- a/roles/flannel/tasks/main.yml
+++ b/roles/flannel/tasks/main.yml
@@ -33,7 +33,7 @@
   copy: src={{ base_dir }}/down/{{ item }} dest=/opt/kube/images/{{ item }}
   when: 'item in download_info.stdout'
   with_items:
-  - "pause_3.1.tar"
+  - "{{ pause_offline }}"
   - "{{ flannel_offline }}"
   ignore_errors: true
 
@@ -46,7 +46,7 @@
   shell: "{{ bin_dir }}/docker load -i /opt/kube/images/{{ item }}"
   when: 'item in image_info.stdout'
   with_items:
-  - "pause_3.1.tar"
+  - "{{ pause_offline }}"
   - "{{ flannel_offline }}"
   ignore_errors: true
 

--- a/roles/kube-node/defaults/main.yml
+++ b/roles/kube-node/defaults/main.yml
@@ -6,3 +6,14 @@ KUBELET_ROOT_DIR: "/var/lib/kubelet"
 
 # node节点最大pod 数
 MAX_PODS: 110
+
+
+# 识别操作系统，加载对应的Pause容器
+OS_VER: "{{ ansible_distribution }}"
+for_redhat_pod: "registry.access.redhat.com/rhel7/pod-infrastructure:latest"
+for_other_pod: "mirrorgooglecontainers/pause-amd64:3.1"
+pod_image: "{%- if OS_VER == 'RedHat' -%} \
+                {{ for_redhat_pod }} \
+            {%- else -%} \
+                {{ for_other_pod }} \
+            {%- endif -%}"

--- a/roles/kube-node/templates/kubelet.service.j2
+++ b/roles/kube-node/templates/kubelet.service.j2
@@ -7,6 +7,7 @@ Requires=docker.service
 [Service]
 WorkingDirectory=/var/lib/kubelet
 #--pod-infra-container-image=registry.access.redhat.com/rhel7/pod-infrastructure:latest
+#--pod-infra-container-image=mirrorgooglecontainers/pause-amd64:3.1
 ExecStart={{ bin_dir }}/kubelet \
   --address={{ inventory_hostname }} \
   --allow-privileged=true \
@@ -24,7 +25,7 @@ ExecStart={{ bin_dir }}/kubelet \
   --kubeconfig=/etc/kubernetes/kubelet.kubeconfig \
   --max-pods={{ MAX_PODS }} \
   --network-plugin=cni \
-  --pod-infra-container-image=mirrorgooglecontainers/pause-amd64:3.1 \
+  --pod-infra-container-image={{ pod_image }} \
   --register-node=true \
   --root-dir={{ KUBELET_ROOT_DIR }} \
   --tls-cert-file={{ ca_dir }}/kubelet.pem \

--- a/roles/kube-router/defaults/main.yml
+++ b/roles/kube-router/defaults/main.yml
@@ -21,3 +21,13 @@ PullPolicy: "IfNotPresent"
 # kube-router 离线镜像tar包
 kuberouter_offline: "kube-router_{{ kube_router_ver }}.tar"
 busybox_offline: "busybox_{{ busybox_ver }}.tar"
+
+# 识别操作系统，加载对应的Pause容器离线镜像tar包
+OS_VER: "{{ ansible_distribution }}"
+for_redhat_pod: "rhel7-pod-infrastructure.tar"
+for_other_pod: "pause_3.1.tar"
+pause_offline: "{%- if OS_VER == 'RedHat' -%} \
+                {{ for_redhat_pod }} \
+              {%- else -%} \
+                {{ for_other_pod }} \
+              {%- endif -%}"

--- a/roles/kube-router/tasks/main.yml
+++ b/roles/kube-router/tasks/main.yml
@@ -48,7 +48,7 @@
   copy: src={{ base_dir }}/down/{{ item }} dest=/opt/kube/images/{{ item }}
   when: 'item in download_info.stdout'
   with_items:
-  - "pause_3.1.tar"
+  - "{{ pause_offline }}"
   - "{{ kuberouter_offline }}"
   - "{{ busybox_offline }}"
   ignore_errors: true
@@ -62,7 +62,7 @@
   shell: "{{ bin_dir }}/docker load -i /opt/kube/images/{{ item }}"
   when: 'item in image_info.stdout'
   with_items:
-  - "pause_3.1.tar"
+  - "{{ pause_offline }}"
   - "{{ kuberouter_offline }}"
   - "{{ busybox_offline }}"
   ignore_errors: true

--- a/roles/lb/tasks/main.yml
+++ b/roles/lb/tasks/main.yml
@@ -16,14 +16,14 @@
 
 - name: yum安装 haproxy
   yum: name=haproxy state=latest
-  when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "7"
+  when: (ansible_distribution == "CentOS" or ansible_distribution == "RedHat") and ansible_distribution_major_version == "7"
 
 - name: 创建haproxy配置目录
   file: name=/etc/haproxy state=directory
 
 - name: 修改centos的haproxy.service
   template: src=haproxy.service.j2 dest=/usr/lib/systemd/system/haproxy.service
-  when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "7"
+  when: (ansible_distribution == "CentOS" or ansible_distribution == "RedHat") and ansible_distribution_major_version == "7"
   tags: restart_lb
 
 - name: 配置 haproxy
@@ -36,7 +36,7 @@
 
 - name: yum安装 keepalived
   yum: name=keepalived state=latest
-  when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "7"
+  when: (ansible_distribution == "CentOS" or ansible_distribution == "RedHat") and ansible_distribution_major_version == "7"
 
 - name: 创建keepalived配置目录
   file: name=/etc/keepalived state=directory

--- a/roles/prepare/tasks/centos.yml
+++ b/roles/prepare/tasks/centos.yml
@@ -1,4 +1,4 @@
-- name: 删除centos默认安装
+- name: 删除centos/redhat默认安装
   yum: 
     name: 
       - firewalld

--- a/roles/prepare/tasks/main.yml
+++ b/roles/prepare/tasks/main.yml
@@ -3,7 +3,7 @@
   when: ansible_distribution == "Ubuntu" or ansible_distribution == "Debian"
 
 - import_tasks: centos.yml
-  when: ansible_distribution == "CentOS"
+  when: (ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
 
 - name: prepare some dirs
   file: name={{ item }} state=directory


### PR DESCRIPTION
1. roles脚本中，识别RedHat。
2. node节点的kubelet根据识别的操作系统，选择加载pause 或者 pod-infrastructure。
3. 各个网络插件根据识别的操作系统，选择加载pause 或者 pod-infrastructure的镜像压缩包。