### PR TITLE
更新docker根目录存储命令

### DIFF
--- a/roles/docker/templates/daemon.json.j2
+++ b/roles/docker/templates/daemon.json.j2
@@ -7,5 +7,5 @@
     "max-size": "{{ LOG_MAX_SIZE }}",
     "max-file": "{{ LOG_MAX_FILE }}"
     },
-  "graph": "{{ STORAGE_DIR }}"
+  "data-root": "{{ STORAGE_DIR }}"
 }


### PR DESCRIPTION
目前graph参数已经废弃,建议使用新的data-root参数设置docker的根目录
![daemon-json](https://user-images.githubusercontent.com/17851645/50953362-18a8d300-14ee-11e9-824d-e5fe8ff8e685.png)
