### PR TITLE
更新kube-schedule监听参数

### DIFF
--- a/roles/kube-master/templates/kube-scheduler.service.j2
+++ b/roles/kube-master/templates/kube-scheduler.service.j2
@@ -4,7 +4,7 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 
 [Service]
 ExecStart={{ bin_dir }}/kube-scheduler \
-  --address=127.0.0.1 \
+  --bind-address=127.0.0.1 \
   --master=http://127.0.0.1:8080 \
   --leader-elect=true \
   --v=2


### PR DESCRIPTION
目前kube-schedule 的监听参数address已经废弃,建议更新至--bind-address
![error](https://user-images.githubusercontent.com/17851645/51107096-ca1a7200-1828-11e9-90d6-f301a75f9807.png)
