### PR TITLE
增加coredns和calico的metrics监控选项

### DIFF
--- a/roles/calico/templates/calico-v3.3.2.yaml.j2
+++ b/roles/calico/templates/calico-v3.3.2.yaml.j2
@@ -192,6 +192,8 @@ spec:
             # Calico will treat traffic to those ports as host traffic instead of pod traffic.
             - name: FELIX_KUBENODEPORTRANGES
               value: "{{ NODE_PORT_RANGE.split('-')[0] }}:{{ NODE_PORT_RANGE.split('-')[1] }}"
+            - name: FELIX_PROMETHEUSMETRICSENABLED
+              value: "true"
           securityContext:
             privileged: true
           resources:

--- a/roles/cluster-addon/templates/coredns.yaml.j2
+++ b/roles/cluster-addon/templates/coredns.yaml.j2
@@ -182,3 +182,7 @@ spec:
   - name: dns-tcp
     port: 53
     protocol: TCP
+  - name: metrics
+    port: 9153
+    protocol: TCP
+    targetPort: 9153


### PR DESCRIPTION
calico通过添加FELIX_PROMETHEUSMETRICSENABLED环境变量开启metrics数据

coredns的metrics端口为9153