### PR TITLE
docker版本判断兼容18.06，示例文件增加直连说明

### DIFF
--- a/example/hosts.m-masters.example
+++ b/example/hosts.m-masters.example
@@ -39,6 +39,7 @@ DEPLOY_MODE=multi-master
 
 # 集群 MASTER IP即 LB节点VIP地址，为区别与默认apiserver端口，设置VIP监听的服务端口8443
 # 公有云上请使用云负载均衡内网地址和监听端口
+# 后端kube-apiserver服务监听6443端口，如果不使用LB，请修改端口
 MASTER_IP="192.168.1.10"
 KUBE_APISERVER="https://{{ MASTER_IP }}:8443"
 

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -5,7 +5,8 @@
 
 # 18.09.x 版本二进制名字有变化，需要做判断
 - name: 获取docker版本信息
-  shell: "{{ base_dir }}/bin/dockerd --version|cut -d' ' -f3"
+  # shell: "{{ base_dir }}/bin/dockerd --version|cut -d' ' -f3"
+  shell: "{{ base_dir }}/bin/dockerd --version|awk -F ',' '{print $1}' |awk -F 'version' '{print $NF}' |awk -F '-' '{print $1}'"
   register: docker_ver
   connection: local
   run_once: true

--- a/roles/prepare/templates/95-k8s-sysctl.conf.j2
+++ b/roles/prepare/templates/95-k8s-sysctl.conf.j2
@@ -7,3 +7,8 @@ net.netfilter.nf_conntrack_max=1000000
 vm.swappiness = 0
 vm.max_map_count=655360
 fs.file-max=655360
+
+# TIME_WAIT
+net.ipv4.tcp_tw_recycle = 1
+net.ipv4.tcp_tw_reuse = 1
+net.ipv4.tcp_timestamps = 1


### PR DESCRIPTION
1.docker version带有ce字样时，转换成浮点数有误。将原cut转换成awk，兼容版本带有ce字样
2.示例主机清单文件增加说明。实际apiserver监听的是6443。