### PR TITLE
fix(down): url for harbor v1.5.x

### DIFF
--- a/down/download.sh
+++ b/down/download.sh
@@ -8,7 +8,7 @@ ETCD_VER=v3.3.8
 DOCKER_VER=17.03.2-ce
 CNI_VER=v0.6.0
 DOCKER_COMPOSE=1.18.0
-HARBOR=1.5.2
+HARBOR=v1.5.4
 
 echo "\nNote1: Before this script, please finish downloading binaries manually from following urls."
 echo "\nNote2：If binaries are not ready, use `Ctrl + C` to stop this script."
@@ -32,7 +32,7 @@ echo "\n----download docker-compose at:"
 echo https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE}/docker-compose-Linux-x86_64
 
 echo "\n----download harbor-offline-installer at:"
-echo https://storage.googleapis.com/harbor-releases/release-${HARBOR}/harbor-offline-installer-v${HARBOR}.tgz
+echo https://storage.googleapis.com/harbor-releases/harbor-offline-installer-${HARBOR}.tgz
 
 echo "\n----download cni plugins at:"
 echo https://github.com/containernetworking/plugins/releases


### PR DESCRIPTION
v1.6+ 下载地址变更为:
https://storage.googleapis.com/harbor-releases/release-1.x.0/harbor-offline-installer-v1.x.y.tgz

比如：
```
https://storage.googleapis.com/harbor-releases/release-1.6.0/harbor-offline-installer-v1.6.2.tgz
```