### PR TITLE
删除不可用的docker cn镜像代理

### DIFF
--- a/docs/guide/gitlab/gitlab-install.md
+++ b/docs/guide/gitlab/gitlab-install.md
@@ -20,7 +20,7 @@ docker run --detach \\
     --volume /srv/gitlab/config:/etc/gitlab \\
     --volume /srv/gitlab/logs:/var/log/gitlab \\
     --volume /srv/gitlab/data:/var/opt/gitlab \\
-    registry.docker-cn.com/gitlab/gitlab-ce:11.2.2-ce.0
+    docker.mirrors.ustc.edu.cn/gitlab/gitlab-ce:11.2.2-ce.0
 EOF
 ```
 执行启动脚本：`sh gitlab-setup.sh` 执行成功后，等待数分钟可以看到
@@ -28,7 +28,7 @@ EOF
 ```
 $ docker ps -a
 CONTAINER ID        IMAGE                                                 COMMAND             CREATED             STATUS                   PORTS                                                            NAMES
-4f9d5f97f494        registry.docker-cn.com/gitlab/gitlab-ce:11.2.2-ce.0   "/assets/wrapper"   9 minutes ago       Up 9 minutes (healthy)   0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp, 0.0.0.0:6022->22/tcp   gitlab
+4f9d5f97f494        docker.mirrors.ustc.edu.cn/gitlab/gitlab-ce:11.2.2-ce.0   "/assets/wrapper"   9 minutes ago       Up 9 minutes (healthy)   0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp, 0.0.0.0:6022->22/tcp   gitlab
 ```
 ## 配置 gitlab
 

--- a/docs/setup/03-install_docker.md
+++ b/docs/setup/03-install_docker.md
@@ -47,7 +47,7 @@ WantedBy=multi-user.target
 
 ``` bash
 {
-  "registry-mirrors": ["https://registry.docker-cn.com"],
+  "registry-mirrors": ["https://docker.mirrors.ustc.edu.cn"],
   "max-concurrent-downloads": 10,
   "log-driver": "json-file",
   "log-level": "warn",

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,7 +1,6 @@
 # 国内镜像加速
 
-REG_MIRROR_1: "https://registry.docker-cn.com"
-REG_MIRROR_2: "https://docker.mirrors.ustc.edu.cn"
+REG_MIRROR_1: "https://docker.mirrors.ustc.edu.cn"
 
 # docker日志相关
 

--- a/roles/docker/templates/daemon.json.j2
+++ b/roles/docker/templates/daemon.json.j2
@@ -1,5 +1,5 @@
 {
-  "registry-mirrors": ["{{ REG_MIRROR_1 }}", "{{ REG_MIRROR_2 }}"], 
+  "registry-mirrors": ["{{ REG_MIRROR_1 }}"],
   "max-concurrent-downloads": 10,
   "log-driver": "{{ LOG_DRIVER }}",
   "log-level": "{{ LOG_LEVEL }}",


### PR DESCRIPTION
在家里已经不可用了，不知道其它地区是否还可用