### PR TITLE
fix: 更正CNI plugins二进制文件下载名[issue 524]

### DIFF
--- a/down/download.sh
+++ b/down/download.sh
@@ -93,14 +93,14 @@ else
 fi
 
 ### prepare cni plugins, needed by flannel;
-if [ -f "cni-${CNI_VER}.tgz" ]; then
+if [ -f "cni-plugins-amd64-${CNI_VER}.tgz" ]; then
   echo "\nextracting cni plugins binaries..."
-  tar zxf cni-${CNI_VER}.tgz
+  tar zxf cni-plugins-amd64-${CNI_VER}.tgz
   mv -f bridge ../bin
   mv -f flannel ../bin
   mv -f host-local ../bin
   mv -f loopback ../bin
   mv -f portmap ../bin
 else
-  echo Please download 'cni-${CNI_VER}.tgz' first
+  echo Please download 'cni-plugins-amd64-${CNI_VER}.tgz' first
 fi


### PR DESCRIPTION
根据CNI plugins github[链接][1]所示，其二进制文件名格式为：`cni-plugins-amd64-${CNI_VER}.tgz`，而非：`cni-${CNI_VER}.tgz`，因此进行更正。

[1]: https://github.com/containernetworking/plugins/releases

Issue #524
Close #524